### PR TITLE
update-glob-10.3.10 for Node19.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	},
 	"homepage": "https://github.com/rei990/vite-plugin-webp-and-path#readme",
 	"dependencies": {
-		"glob": "^7.1.7",
+		"glob": "^10.3.10",
 		"imagemin": "^8.0.0",
 		"imagemin-webp": "^7.0.0",
 		"path": "^0.12.7",


### PR DESCRIPTION
ちょうど LP の案件で webp 変換できるものを探していたところこちらのリポジトリを見つけて感謝！の気持ちです。
自分の環境だと Node 19 系で glob.sync でエラーが発生して動かなかったので対応したものをプルリクエスト送らせていただきます。

エラー内容は glob.sync is not a function だったのですが、調べたところ glob バージョン9 で解決しているようなのでシンプルに glob のバージョンを引き上げてインストールするように package.json の指定を書き換えました。

ご確認の上取り込んでいただけると幸いです

glob の問題に対する issue https://github.com/isaacs/node-glob/issues/493