### PR TITLE
元ファイルのJSファイルに画像パスがある場合にもWebp変換を追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const VitePluginWebpAndPath = (options: Options = {}) => {
 	const {
 		targetDir = './dist/',
 		imgExtensions = 'jpg,png',
-		textExtensions = 'html,css',
+		textExtensions = 'html,css,js',
 		quality = 80,
 		enableLogs = true,
 	} = options;


### PR DESCRIPTION
JSに記載したファイルパスだと現状webpに変換出来ないので、対応できるようコード追記しました。
良ければ取り込んでいただけると嬉しいです。